### PR TITLE
No recursive readdir

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -114,19 +114,20 @@ void GameList::LoadInterfaceLayout()
     item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
 }
 
-void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, bool deep_scan)
+void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion)
 {
     const auto callback = [&](unsigned* num_entries_out,
                               const std::string& directory,
-                              const std::string& virtual_name) -> bool {
+                              const std::string& virtual_name,
+                              unsigned int recursion) -> bool {
 
         std::string physical_name = directory + DIR_SEP + virtual_name;
 
         if (stop_processing)
             return false; // Breaks the callback loop.
 
-        if (deep_scan && FileUtil::IsDirectory(physical_name)) {
-            AddFstEntriesToGameList(physical_name, true);
+        if (recursion > 0 && FileUtil::IsDirectory(physical_name)) {
+            AddFstEntriesToGameList(physical_name, recursion - 1);
         } else {
             std::string filename_filename, filename_extension;
             Common::SplitPath(physical_name, nullptr, &filename_filename, &filename_extension);
@@ -159,7 +160,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, bool d
 void GameListWorker::run()
 {
     stop_processing = false;
-    AddFstEntriesToGameList(dir_path.toStdString(), deep_scan);
+    AddFstEntriesToGameList(dir_path.toStdString(), deep_scan ? 1000 : 0);
     emit Finished();
 }
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -126,5 +126,5 @@ private:
     bool deep_scan;
     std::atomic_bool stop_processing;
 
-    void AddFstEntriesToGameList(const std::string& dir_path, bool deep_scan);
+    void AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion = 0);
 };

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -105,11 +105,13 @@ bool CreateEmptyFile(const std::string &filename);
  * @param num_entries_out to be assigned by the callable with the number of iterated directory entries, never null
  * @param directory the path to the enclosing directory
  * @param virtual_name the entry name, without any preceding directory info
+ * @param recursion Number of children directory to read before giving up
  * @return whether handling the entry succeeded
  */
 using DirectoryEntryCallable = std::function<bool(unsigned* num_entries_out,
                                                  const std::string& directory,
-                                                 const std::string& virtual_name)>;
+                                                 const std::string& virtual_name,
+                                                 unsigned int recursion)>;
 
 /**
  * Scans a directory, calling the callback for each file/directory contained within.
@@ -117,20 +119,22 @@ using DirectoryEntryCallable = std::function<bool(unsigned* num_entries_out,
  * @param num_entries_out assigned by the function with the number of iterated directory entries, can be null
  * @param directory the directory to scan
  * @param callback The callback which will be called for each entry
+ * @param recursion Number of children directory to read before giving up
  * @return whether scanning the directory succeeded
  */
-bool ForeachDirectoryEntry(unsigned* num_entries_out, const std::string &directory, DirectoryEntryCallable callback);
+bool ForeachDirectoryEntry(unsigned* num_entries_out, const std::string &directory, DirectoryEntryCallable callback, unsigned int recursion = 0);
 
 /**
  * Scans the directory tree, storing the results.
  * @param directory the parent directory to start scanning from
  * @param parent_entry FSTEntry where the filesystem tree results will be stored.
+ * @param recursion Number of children directory to read before giving up.
  * @return the total number of files/directories found
  */
-unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry);
+unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry, unsigned int recursion = 0);
 
 // deletes the given directory and anything under it. Returns true on success.
-bool DeleteDirRecursively(const std::string &directory);
+bool DeleteDirRecursively(const std::string &directory, unsigned int recursion = 0);
 
 // Returns the current directory
 std::string GetCurrentDir();


### PR DESCRIPTION
I've attempted to rebase this because I want to close the old issue.

I didn't test this tbh as I just wanted to see what would have to be changed.
This probably still needs some work and some configured recursion depth (otherwise this effectively turns `DeleteDirRecursively` into `DeleteDir` which fails if it contains subdirs (?))
I've arbritarily chosen 1000 as an "okay depth" for deep_scan in the gamelist because most filesystems probably fail before that.

I'll consider my changes public domain - do as you wish, no credit necessary.
Also feel free to discard this altogether or hate me for bringing back horror from the past :P .
